### PR TITLE
APM-2762 Move SpikeArrest/Quota checks inside non-ping Flows

### DIFF
--- a/proxies/live/apiproxy/proxies/default.xml
+++ b/proxies/live/apiproxy/proxies/default.xml
@@ -1,13 +1,5 @@
 <ProxyEndpoint name="default">
   <PreFlow>
-    <Request>
-      <Step>
-        <Name>SpikeArrest</Name>
-      </Step>
-      <Step>
-        <Name>Quota</Name>
-      </Step>
-    </Request>
     <Response>
       <Step>
         <Name>AssignMessage.AddCors</Name>
@@ -17,6 +9,12 @@
   <Flows>
     <Flow name="JkuEndpoint">
       <Request>
+        <Step>
+          <Name>SpikeArrest</Name>
+        </Step>
+        <Step>
+          <Name>Quota</Name>
+        </Step>
         <Step>
           <Name>RaiseFault.400BadRequest</Name>
           <Condition>request.queryparam.clientId = null OR request.queryparam.clientId = ""</Condition>
@@ -62,6 +60,12 @@
     </Flow>
     <Flow name="JwksEndpoint">
       <Request>
+        <Step>
+          <Name>SpikeArrest</Name>
+        </Step>
+        <Step>
+          <Name>Quota</Name>
+        </Step>
         <Step>
           <Name>RaiseFault.400BadRequest</Name>
           <Condition>request.queryparam.clientId = null OR request.queryparam.clientId = ""</Condition>


### PR DESCRIPTION
Having these in the pre-flow was causing _ping checks to occasionally
fail in `prod` environment.